### PR TITLE
Issue #72 関連の暫定対処

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,3 +7,6 @@ end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false

--- a/README.md
+++ b/README.md
@@ -54,6 +54,11 @@ pnpm --filter atcoder-inbrowser-playground-extension run zip:chrome
 pnpm --filter atcoder-inbrowser-playground-extension run zip:firefox
 ```
 
+> [!CAUTION]
+> Chrome向け開発環境(`... run dev:chrome`)ではコードテスト実行機能が動作しないことが確認されています。  
+> 当該機能の開発をChromeで行う場合は、都度`build:chrome`したものを読み込むようにしてください。  
+> 詳細は[Issue #72](https://github.com/AXT-Studio/AtCoder-InBrowser-Playground/issues/72)を参照してください。
+
 拡張機能のバージョンは`wxt.config.ts`の`version`フィールドで管理されます。
 
 ### Load as Unpacked Extension (Firefox)

--- a/apps/extension/entrypoints/mv3_runner/main.ts
+++ b/apps/extension/entrypoints/mv3_runner/main.ts
@@ -94,7 +94,7 @@ const execute = async (message: RunnerWorkerExecMessageData): Promise<CodeTestRe
     }
 };
 
-browser.runtime.onMessage.addListener((message, sender) => {
+browser.runtime.onMessage.addListener((message, sender, sendResponse) => {
     // ==== exec メッセージ以外は無視 ====
     if (message.type !== "exec") return;
     // ==== Content Scriptから直接来たものは無視し、Backgroundからの転送のみ処理する ====
@@ -104,7 +104,13 @@ browser.runtime.onMessage.addListener((message, sender) => {
     if (manifestVersion !== 2 && manifestVersion !== 3) return;
 
     // ==== コード実行処理を呼び出す ====
-    const result = execute(message as RunnerWorkerExecMessageData);
-    // ==== 結果をContent Scriptに返す ====
-    return result;
+    void execute(message as RunnerWorkerExecMessageData)
+        .then((result) => {
+            sendResponse(result);
+        })
+        .catch((error) => {
+            const errorMessage = error instanceof Error ? error.message : String(error);
+            sendResponse(asCompileErrorResult(errorMessage));
+        });
+    return true;
 });


### PR DESCRIPTION
1. return true → sendResponseを採用できる箇所がもう一個あったのでそこは適用 
    - Issue #72 の調査中に見つけたもの。
    - これ自体は #72 の解消にあまり関係がなく、そもそも #72 は修正断念という形になったのでこのままPR
2. Issue #72 関連の記述をREADMEに追加
    - 断念することになったので……