### PR TITLE
フォントロード後に明示的にインデント幅(px)を再計算するように変更

### DIFF
--- a/entrypoints/main.content/UI/monaco/setup.ts
+++ b/entrypoints/main.content/UI/monaco/setup.ts
@@ -136,6 +136,25 @@ export type CreateMonacoEditorOptions = {
     onChange: (value: string) => void;
 };
 
+const MONACO_FONT_FAMILY = "'M PLUS 1 Code', ui-monospace, monospace";
+const MONACO_FONT_SIZE = 13;
+
+/**
+ * Google Fonts（display=swap）完了前に測ると spaceWidth がフォールバック幅でキャッシュされ、
+ * indent guide が本文からずれる（#82）。ロード後に再計測する。
+ */
+const remeasureMonacoFontsWhenReady = (): void => {
+    void (async () => {
+        try {
+            await document.fonts.load(`${MONACO_FONT_SIZE}px "M PLUS 1 Code"`);
+        } catch {
+            // フォント取得失敗時も ready 後の再計測でフォールバック幅を確定させる
+        }
+        await document.fonts.ready;
+        monacoEditor.remeasureFonts();
+    })();
+};
+
 export const createMonacoEditor = (options: CreateMonacoEditorOptions): editor.IStandaloneCodeEditor => {
     ensureMonacoEnvironment();
     ensureMonacoCompilerOptions();
@@ -145,9 +164,9 @@ export const createMonacoEditor = (options: CreateMonacoEditorOptions): editor.I
         language: toMonacoLanguage(options.language),
         automaticLayout: true,
         theme: "vs-dark",
-        minimap: { enabled: false },
-        fontFamily: "'M PLUS 1 Code', ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace",
-        fontSize: 13,
+        minimap: { enabled: false }, // <- これをfalseにしないとFirefoxで動作しないっぽい
+        fontFamily: MONACO_FONT_FAMILY,
+        fontSize: MONACO_FONT_SIZE,
         lineHeight: 20,
         scrollBeyondLastLine: false,
         glyphMargin: true,
@@ -181,6 +200,8 @@ export const createMonacoEditor = (options: CreateMonacoEditorOptions): editor.I
             suppressChangeEvent = false;
         }
     };
+
+    remeasureMonacoFontsWhenReady();
 
     return instance;
 };

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -22,7 +22,7 @@ export default defineConfig({
             permissions.push("offscreen");
         }
         return {
-            version: "2.0.0",
+            version: "2.0.1",
             name: "AtCoder In-Browser Playground",
             description: "AtCoderの問題ページ上でコードを書いて実行・テストできる拡張機能",
             permissions,


### PR DESCRIPTION
close #82 

フォントロード前にインデント幅が計算されていることが原因だったっぽい