### PR TITLE
コード保存の同期ズレでカーソルがエディタ先頭に飛ぶ事がある問題を修正

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -172,7 +172,7 @@ Heuristic / ML 系（pandas, sklearn, torch 等）は対象外。
 ### 7.1 技術
 
 - Preact + Preact Signals
-- Monaco は imperative（ref + mount/dispose）
+- Monaco は imperative（ref + mount/dispose）。**テキストの正本は Monaco**（Signals は onChange で片方向追従。props から setValue しない）
 
 ### 7.2 Mode = やりたいこと（＝編集バッファ）
 

--- a/entrypoints/main.content/UI/App.css
+++ b/entrypoints/main.content/UI/App.css
@@ -13,7 +13,7 @@
 }
 
 .aibp-panel__chrome :is(code, pre, textarea) {
-    font-family: "M PLUS 1 Code", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+    font-family: monospace;
 }
 
 /* Prepare Submission 拒否時の行ハイライト（一時フラッシュ） */

--- a/entrypoints/main.content/UI/applyTemplateInsert.ts
+++ b/entrypoints/main.content/UI/applyTemplateInsert.ts
@@ -1,15 +1,23 @@
+import type { editor } from "monaco-editor";
 import { getPageContext } from "@/utils/atcoder/pageContext";
 import { insertTemplate, listTemplates } from "@/utils/templates";
 import type { BufferKind } from "@/utils/persistence/editorBuffers";
+import { foldClassDeclarations } from "./monaco/foldLines";
+import { setEditorValueExternal } from "./monaco/setup";
 import { setBufferCode } from "./state";
 
 /** 言語変更時に選ぶデフォルトテンプレ ID */
 export const defaultTemplateId = (language: string, role: BufferKind): string =>
     listTemplates(language, role)[0]?.id ?? "";
 
-/** Template Insert ボタンの共通処理 */
-export const applyTemplateInsert = (params: { buffer: BufferKind; templateKey: string; currentCode: string }): void => {
+/** Template Insert ボタンの共通処理（Monaco 正本: editor へ直接書き、Signals は追従） */
+export const applyTemplateInsert = (params: {
+    buffer: BufferKind;
+    templateKey: string;
+    editor: editor.IStandaloneCodeEditor | null;
+}): void => {
     if (!params.templateKey) return;
+    if (!params.editor) return;
 
     const { contestTitle, taskTitle, taskURL } = getPageContext();
     const result = insertTemplate({
@@ -18,11 +26,13 @@ export const applyTemplateInsert = (params: { buffer: BufferKind; templateKey: s
         taskTitle,
         taskURL,
         role: params.buffer,
-        currentCode: params.currentCode,
+        currentCode: params.editor.getValue(),
         confirm: (message) => window.confirm(message),
     });
 
     if (result.action === "insert") {
+        setEditorValueExternal(params.editor, result.template);
         setBufferCode(params.buffer, result.template);
+        foldClassDeclarations(params.editor, { delayMs: 100 });
     }
 };

--- a/entrypoints/main.content/UI/controls.css
+++ b/entrypoints/main.content/UI/controls.css
@@ -197,7 +197,7 @@
     padding: 0.75rem;
     resize: none;
     background: #f8fafc;
-    font-family: "M PLUS 1 Code", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+    font-family: monospace;
     font-size: 13px;
     line-height: 1.5;
 }
@@ -343,7 +343,7 @@
     height: 10rem;
     padding: 0.5rem 0.6rem;
     resize: none;
-    font-family: "M PLUS 1 Code", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+    font-family: monospace;
     font-size: 12px;
     line-height: 1.45;
 }

--- a/entrypoints/main.content/UI/fonts.css
+++ b/entrypoints/main.content/UI/fonts.css
@@ -1,6 +1,6 @@
 /**
- * UI / コード用フォント（Google Fonts）。
+ * UI 用フォント（Google Fonts）。コード用はシステム monospace を使う。
  * 同梱 @fontsource は content CSS に base64 インラインされて数 MB 化し、
  * Firefox の「応答のないスクリプト」の主因になったため使わない。
  */
-@import url("https://fonts.googleapis.com/css2?family=M+PLUS+1+Code:wght@100..700&family=M+PLUS+1:wght@100..900&display=swap");
+@import url("https://fonts.googleapis.com/css2?family=M+PLUS+1:wght@100..900&display=swap");

--- a/entrypoints/main.content/UI/modes/Compare.tsx
+++ b/entrypoints/main.content/UI/modes/Compare.tsx
@@ -1,5 +1,6 @@
 import { useRef } from "preact/hooks";
 import { useSignal } from "@preact/signals";
+import type { editor } from "monaco-editor";
 import { parseSampleCases } from "@/utils/atcoder/parseSampleCases";
 import type { ExecRequestMessage, ExecResponseMessage } from "@/utils/execution/types";
 import { listTemplates } from "@/utils/templates";
@@ -37,6 +38,7 @@ export function Compare() {
     const running = useSignal(false);
     const selectedTemplate = useSignal(defaultTemplateId(naiveLanguage.value, "naive"));
     const templateOptions = listTemplates(naiveLanguage.value, "naive");
+    const monacoEditorRef = useRef<editor.IStandaloneCodeEditor | null>(null);
 
     const execOnce = async (language: string, code: string, stdinValue: string) => {
         const req = {
@@ -106,8 +108,9 @@ export function Compare() {
         <>
             <div class="aibp-editor">
                 <MonacoEditor
-                    value={naiveCode.value}
+                    initialValue={naiveCode.value}
                     language={naiveLanguage.value}
+                    editorRef={monacoEditorRef}
                     onChange={(value) => {
                         setBufferCode("naive", value);
                     }}
@@ -168,7 +171,7 @@ export function Compare() {
                                 applyTemplateInsert({
                                     buffer: "naive",
                                     templateKey: selectedTemplate.value,
-                                    currentCode: naiveCode.value,
+                                    editor: monacoEditorRef.current,
                                 });
                             }}
                         >

--- a/entrypoints/main.content/UI/modes/Solve.tsx
+++ b/entrypoints/main.content/UI/modes/Solve.tsx
@@ -94,7 +94,7 @@ export function Solve() {
         <>
             <div class="aibp-editor">
                 <MonacoEditor
-                    value={submissionCode.value}
+                    initialValue={submissionCode.value}
                     language={submissionLanguage.value}
                     editorRef={monacoEditorRef}
                     onChange={(value) => {
@@ -157,7 +157,7 @@ export function Solve() {
                                 applyTemplateInsert({
                                     buffer: "submission",
                                     templateKey: selectedTemplate.value,
-                                    currentCode: submissionCode.value,
+                                    editor: monacoEditorRef.current,
                                 });
                             }}
                         >

--- a/entrypoints/main.content/UI/modes/Stress.tsx
+++ b/entrypoints/main.content/UI/modes/Stress.tsx
@@ -1,4 +1,6 @@
+import { useRef } from "preact/hooks";
 import { useSignal } from "@preact/signals";
+import type { editor } from "monaco-editor";
 import type { ExecRequestMessage, ExecResponseMessage } from "@/utils/execution/types";
 import { listTemplates } from "@/utils/templates";
 import { judgeStressIteration } from "@/utils/stdout/judgeStressIteration";
@@ -31,6 +33,7 @@ export function Stress() {
     const running = useSignal(false);
     const selectedTemplate = useSignal(defaultTemplateId(generatorLanguage.value, "generator"));
     const templateOptions = listTemplates(generatorLanguage.value, "generator");
+    const monacoEditorRef = useRef<editor.IStandaloneCodeEditor | null>(null);
 
     const execOnce = async (language: string, code: string, stdinValue: string) => {
         const req = {
@@ -123,8 +126,9 @@ export function Stress() {
         <>
             <div class="aibp-editor">
                 <MonacoEditor
-                    value={generatorCode.value}
+                    initialValue={generatorCode.value}
                     language={generatorLanguage.value}
+                    editorRef={monacoEditorRef}
                     onChange={(value) => {
                         setBufferCode("generator", value);
                     }}
@@ -185,7 +189,7 @@ export function Stress() {
                                 applyTemplateInsert({
                                     buffer: "generator",
                                     templateKey: selectedTemplate.value,
-                                    currentCode: generatorCode.value,
+                                    editor: monacoEditorRef.current,
                                 });
                             }}
                         >

--- a/entrypoints/main.content/UI/monaco/MonacoEditor.tsx
+++ b/entrypoints/main.content/UI/monaco/MonacoEditor.tsx
@@ -1,29 +1,28 @@
 import { useEffect, useRef } from "preact/hooks";
 import type { editor } from "monaco-editor";
 import { foldClassDeclarations } from "./foldLines";
-import { createMonacoEditor, setEditorValueExternal, setMonacoLanguage } from "./setup";
+import { createMonacoEditor, setMonacoLanguage } from "./setup";
 
 export type MonacoEditorProps = {
-    value: string;
+    /** mount 時の初期値のみ。以降の正本は Monaco（Signals へは onChange で片方向） */
+    initialValue: string;
     language: string;
     onChange: (value: string) => void;
     class?: string;
-    /** 親から Prepare Submission 等で editor 実体を触るとき用 */
+    /** 親から Prepare Submission / Template Insert 等で editor 実体を触るとき用 */
     editorRef?: { current: editor.IStandaloneCodeEditor | null };
 };
 
 /**
  * Preact 向け Monaco ラッパ（imperative create / dispose）。
- * value の外部更新はモデルへ同期。入力中の自分自身の onChange はループしないよう参照比較する。
- * 外部からコードが入ったときは旧実装どおり `class` 行を折る（Insert / hydrate）。
+ * テキストの正本は Monaco。props から setValue で書き戻さない（#84: controlled 同期のレース回避）。
+ * 外部更新（Template Insert 等）は editorRef 経由で setEditorValueExternal する。
  */
 export function MonacoEditor(props: MonacoEditorProps) {
     const containerRef = useRef<HTMLDivElement>(null);
     const editorRef = useRef<editor.IStandaloneCodeEditor | null>(null);
     const onChangeRef = useRef(props.onChange);
     onChangeRef.current = props.onChange;
-    /** 自分が onChange で吐き出した値（外部同期と区別する） */
-    const lastEmittedRef = useRef(props.value);
 
     useEffect(() => {
         const container = containerRef.current;
@@ -31,15 +30,13 @@ export function MonacoEditor(props: MonacoEditorProps) {
 
         const instance = createMonacoEditor({
             container,
-            value: props.value,
+            value: props.initialValue,
             language: props.language,
             onChange: (value) => {
-                lastEmittedRef.current = value;
                 onChangeRef.current(value);
             },
         });
         editorRef.current = instance;
-        lastEmittedRef.current = props.value;
         if (props.editorRef) {
             props.editorRef.current = instance;
         }
@@ -52,21 +49,8 @@ export function MonacoEditor(props: MonacoEditorProps) {
             instance.dispose();
             editorRef.current = null;
         };
+        // mount 時のみ。テキストは Monaco 正本、language は別 effect で同期
     }, []);
-
-    useEffect(() => {
-        const instance = editorRef.current;
-        if (!instance) return;
-        // 自分の入力で上がってきた value では setValue しない（補完中の往復を避ける）
-        if (props.value === lastEmittedRef.current) return;
-        if (instance.getValue() === props.value) {
-            lastEmittedRef.current = props.value;
-            return;
-        }
-        setEditorValueExternal(instance, props.value);
-        lastEmittedRef.current = props.value;
-        foldClassDeclarations(instance, { delayMs: 100 });
-    }, [props.value]);
 
     useEffect(() => {
         const instance = editorRef.current;

--- a/entrypoints/main.content/UI/monaco/setup.ts
+++ b/entrypoints/main.content/UI/monaco/setup.ts
@@ -185,7 +185,7 @@ export const createMonacoEditor = (options: CreateMonacoEditorOptions): editor.I
     return instance;
 };
 
-/** 外部からのコード同期（Insert / hydrate）。onChange を発火させない */
+/** 外部からのコード投入（Template Insert 等）。onChange を発火させないので、呼び出し側で Signals も更新すること */
 export const setEditorValueExternal = (instance: editor.IStandaloneCodeEditor, value: string): void => {
     const withHook = instance as editor.IStandaloneCodeEditor & {
         __aibpSetValue?: (value: string) => void;

--- a/entrypoints/main.content/UI/monaco/setup.ts
+++ b/entrypoints/main.content/UI/monaco/setup.ts
@@ -136,25 +136,6 @@ export type CreateMonacoEditorOptions = {
     onChange: (value: string) => void;
 };
 
-const MONACO_FONT_FAMILY = "'M PLUS 1 Code', ui-monospace, monospace";
-const MONACO_FONT_SIZE = 13;
-
-/**
- * Google Fonts（display=swap）完了前に測ると spaceWidth がフォールバック幅でキャッシュされ、
- * indent guide が本文からずれる（#82）。ロード後に再計測する。
- */
-const remeasureMonacoFontsWhenReady = (): void => {
-    void (async () => {
-        try {
-            await document.fonts.load(`${MONACO_FONT_SIZE}px "M PLUS 1 Code"`);
-        } catch {
-            // フォント取得失敗時も ready 後の再計測でフォールバック幅を確定させる
-        }
-        await document.fonts.ready;
-        monacoEditor.remeasureFonts();
-    })();
-};
-
 export const createMonacoEditor = (options: CreateMonacoEditorOptions): editor.IStandaloneCodeEditor => {
     ensureMonacoEnvironment();
     ensureMonacoCompilerOptions();
@@ -165,8 +146,8 @@ export const createMonacoEditor = (options: CreateMonacoEditorOptions): editor.I
         automaticLayout: true,
         theme: "vs-dark",
         minimap: { enabled: false }, // <- これをfalseにしないとFirefoxで動作しないっぽい
-        fontFamily: MONACO_FONT_FAMILY,
-        fontSize: MONACO_FONT_SIZE,
+        fontFamily: "monospace",
+        fontSize: 13,
         lineHeight: 20,
         scrollBeyondLastLine: false,
         glyphMargin: true,
@@ -200,8 +181,6 @@ export const createMonacoEditor = (options: CreateMonacoEditorOptions): editor.I
             suppressChangeEvent = false;
         }
     };
-
-    remeasureMonacoFontsWhenReady();
 
     return instance;
 };

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -22,7 +22,7 @@ export default defineConfig({
             permissions.push("offscreen");
         }
         return {
-            version: "2.0.1",
+            version: "2.0.2",
             name: "AtCoder In-Browser Playground",
             description: "AtCoderの問題ページ上でコードを書いて実行・テストできる拡張機能",
             permissions,


### PR DESCRIPTION
close #84 
Preact採用したタイミングでMonaco Editor側のコードを正本とすることを忘れてしまっていたのが原因でした