### PR TITLE
Bun×再帰DFSの判定条件を変更

### DIFF
--- a/utils/atcoder/prepareSubmissionGuards.test.ts
+++ b/utils/atcoder/prepareSubmissionGuards.test.ts
@@ -2,9 +2,21 @@ import { describe, expect, it } from "vitest";
 import { shouldWarnDfsAndBun } from "./prepareSubmissionGuards";
 
 describe("shouldWarnDfsAndBun", () => {
-    it("warns only when both dfs and Bun appear", () => {
+    it("warns when a dfs declaration and Bun. both appear", () => {
         expect(shouldWarnDfsAndBun("function dfs() {}\nMain(await Bun.file")).toBe(true);
+        expect(shouldWarnDfsAndBun("const dfs = () => {}\nMain(await Bun.file")).toBe(true);
+        expect(shouldWarnDfsAndBun("let dfs = () => {}\nMain(await Bun.file")).toBe(true);
+        expect(shouldWarnDfsAndBun("function  dfs () {}\nMain(await Bun.file")).toBe(true);
+        expect(shouldWarnDfsAndBun("const  dfs  = () => {}\nMain(await Bun.file")).toBe(true);
+        expect(shouldWarnDfsAndBun("let  dfs  = () => {}\nMain(await Bun.file")).toBe(true);
+    });
+
+    it("does not warn without both a dfs declaration and Bun.", () => {
         expect(shouldWarnDfsAndBun("function dfs() {}")).toBe(false);
+        expect(shouldWarnDfsAndBun("const dfs = () => {}")).toBe(false);
+        expect(shouldWarnDfsAndBun("let dfs = () => {}")).toBe(false);
         expect(shouldWarnDfsAndBun("await Bun.file('/dev/stdin').text()")).toBe(false);
+        expect(shouldWarnDfsAndBun("dfs(0)\nMain(await Bun.file")).toBe(false);
+        expect(shouldWarnDfsAndBun("// dfs\nMain(await Bun.file")).toBe(false);
     });
 });

--- a/utils/atcoder/prepareSubmissionGuards.ts
+++ b/utils/atcoder/prepareSubmissionGuards.ts
@@ -3,4 +3,6 @@ export const WARNING_MESSAGE_ON_DFS_AND_BUN = `\
 Warning: Are you trying to do recursive DFS in the Bun environment? You may get a penalty (Runtime Error) due to stack overflow. Do you want to proceed?
 `;
 
-export const shouldWarnDfsAndBun = (code: string): boolean => code.includes("dfs") && code.includes("Bun");
+const DFS_DECLARATION_RE = /(?:(?:const|let)\s+dfs\s*=|function\s+dfs\b)/;
+
+export const shouldWarnDfsAndBun = (code: string): boolean => DFS_DECLARATION_RE.test(code) && code.includes("Bun.");


### PR DESCRIPTION
close #93.
誤検知が発生しづらくなるはずです。